### PR TITLE
Dark Mode CSS Bug Fix

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -2,6 +2,7 @@
 
 .dark {
   background-color: #15202b;
+  min-height: 100vh;
 }
 
 .dark div {


### PR DESCRIPTION
In darkmode on a large screen the container color does not fill the screen:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/10408955/194771504-cb615793-826c-4505-a264-2af14b9c9d90.png">

My fix will allow for full screen filling of the color
<img width="954" alt="image" src="https://user-images.githubusercontent.com/10408955/194771535-c4d66e87-3e20-42f6-bd08-e294cca8e7bc.png">
