### PR TITLE
Replaced Math.random

### DIFF
--- a/src/password.js
+++ b/src/password.js
@@ -52,7 +52,7 @@ function pickRandomElement(parameter){
 }
 
 function randomNumber() {
-    const array = new Uint32Array(10);
+    const array = new Uint32Array(1);
     const number = window.crypto.getRandomValues(array)[0];
 
     return parseFloat("0." + number)

--- a/src/password.js
+++ b/src/password.js
@@ -22,7 +22,7 @@ export default function generatePassword(length , setting){
         for(let i=0; i<=length-1; i++){
             // alphabet or number
 
-            const type = listOfTypes[Math.floor(Math.random() * listOfTypes.length)];
+            const type = listOfTypes[Math.floor(randomNumber() * listOfTypes.length)];
 
             // console.log("Type: " + type);
             if(type === "al"){
@@ -47,6 +47,13 @@ export default function generatePassword(length , setting){
 }
 
 function pickRandomElement(parameter){
-    const r = parameter[Math.floor(Math.random() * parameter.length)];
+    const r = parameter[Math.floor(randomNumber() * parameter.length)];
     return r
+}
+
+function randomNumber() {
+    const array = new Uint32Array(10);
+    const number = window.crypto.getRandomValues(array)[0];
+
+    return parseFloat("0." + number)
 }


### PR DESCRIPTION
Math.random should never be used for generating passwords due to being predictable. Even at low scale, it's not good practice. Replaced it with a Crypto.getRandomValues solution instead.