### PR TITLE
feature: persist theme preference on local storage

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from "react";
 import generatePassword from "../password";
+import { usePersistedState } from "../hooks/usePersistedState";
 import PasswordDisplay from "./PasswordDisplay";
 import CheckBoxes from "./CheckBoxes";
 import Tips from "./Tips";
@@ -15,7 +16,10 @@ import {
 } from "@mui/material";
 
 export default function App() {
-  const [theme, setTheme] = useState("light");
+  const [theme, setTheme] = usePersistedState(
+    "@password-generator/theme",
+    "light"
+  );
   const [password, setPassword] = useState(null);
   const [length, setLength] = useState(4);
   const [open, setOpen] = useState(false);

--- a/src/hooks/usePersistedState.js
+++ b/src/hooks/usePersistedState.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export function usePersistedState(key, initialState) {
+  const [state, setState] = useState(() => {
+    const persistedState = localStorage.getItem(key);
+
+    return persistedState ? JSON.parse(persistedState) : initialState;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [state, key]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
Hey, friend! :wave: 

First of all, congrats for the amazing job on integrating this project with the community! 

This is an enhancement on the theme choice. Now the theme is saved on the user's local storage so the chosen theme will be automatically applied on subsequent page visits.